### PR TITLE
Fix wrong argument in NetworkDelayEvent scheduling

### DIFF
--- a/sfctss/model/sfi.py
+++ b/sfctss/model/sfi.py
@@ -266,7 +266,7 @@ class SFI(object):
             self.sim.schedule_event(NetworkDelayEvent(delay=delay,
                                                       inner_packet=packet,
                                                       source=self,
-                                                      dest_id=self.sffId,
+                                                      dest_id=next_hop.id,
                                                       source_is_sff=False,
                                                       dest_is_sff=True))
         
@@ -279,7 +279,7 @@ class SFI(object):
             self.sim.schedule_event(NetworkDelayEvent(delay=delay,
                                                       inner_packet=packet,
                                                       source=self,
-                                                      dest_id=self.next_hop.id,
+                                                      dest_id=next_hop.id,
                                                       source_is_sff=False,
                                                       dest_is_sff=False))
         else:

--- a/sfctss/model/sfi.py
+++ b/sfctss/model/sfi.py
@@ -279,7 +279,7 @@ class SFI(object):
             self.sim.schedule_event(NetworkDelayEvent(delay=delay,
                                                       inner_packet=packet,
                                                       source=self,
-                                                      dest_id=self.sffId,
+                                                      dest_id=self.next_hop.id,
                                                       source_is_sff=False,
                                                       dest_is_sff=False))
         else:


### PR DESCRIPTION
Hello. Thank you for releasing the source code of the experiment.
Here are the bugs I found.

Because the SFF ID is specified when the packet is forwarded to SFI, the packet is sent to the wrong destination.

Please contact me if I am wrong in pointing this out.